### PR TITLE
ignore machine-dependent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+pnpm-lock.yaml


### PR DESCRIPTION
This pull request will ignore machine-dependent files. For example, we do not want to push the node modules folder (the developer should be responsible of installing their own; the package.json is the reference to download all application dependencies).

Furthermore, the developer should decide whether to use pnpm or npm for package management, so products of those two (pnpm-lock.yaml and package-lock.json) should be ignored as well.